### PR TITLE
IMAPMockFolder should return null for unknown UID

### DIFF
--- a/src/main/java/de/saly/javamail/mock2/IMAPMockFolder.java
+++ b/src/main/java/de/saly/javamail/mock2/IMAPMockFolder.java
@@ -25,11 +25,13 @@
  **********************************************************************************************************************/
 package de.saly.javamail.mock2;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Semaphore;
+import com.sun.mail.iap.ProtocolException;
+import com.sun.mail.iap.Response;
+import com.sun.mail.imap.AppendUID;
+import com.sun.mail.imap.IMAPFolder;
+import com.sun.mail.imap.ResyncData;
+import com.sun.mail.imap.SortTerm;
+import de.saly.javamail.mock2.MailboxFolder.MailboxEventListener;
 
 import javax.mail.FetchProfile;
 import javax.mail.Flags;
@@ -46,15 +48,11 @@ import javax.mail.event.MailEvent;
 import javax.mail.event.MessageChangedEvent;
 import javax.mail.internet.MimeMessage;
 import javax.mail.search.SearchTerm;
-
-import com.sun.mail.iap.ProtocolException;
-import com.sun.mail.iap.Response;
-import com.sun.mail.imap.AppendUID;
-import com.sun.mail.imap.IMAPFolder;
-import com.sun.mail.imap.ResyncData;
-import com.sun.mail.imap.SortTerm;
-
-import de.saly.javamail.mock2.MailboxFolder.MailboxEventListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
 
 public class IMAPMockFolder extends IMAPFolder implements MailboxEventListener {
 
@@ -396,7 +394,8 @@ public class IMAPMockFolder extends IMAPFolder implements MailboxEventListener {
         abortIdle();
         checkExists();
         checkOpened();
-        return new MockMessage(mailboxFolder.getById(uid), this);
+        Message message = mailboxFolder.getById(uid);
+        return message != null ? new MockMessage(message, this) : null;
     }
 
     @Override

--- a/src/test/java/de/saly/javamail/mock2/test/IMAPTestCase.java
+++ b/src/test/java/de/saly/javamail/mock2/test/IMAPTestCase.java
@@ -25,8 +25,14 @@
  **********************************************************************************************************************/
 package de.saly.javamail.mock2.test;
 
-import java.util.Arrays;
-import java.util.Properties;
+import com.sun.mail.imap.IMAPFolder;
+import com.sun.mail.imap.IMAPStore;
+import de.saly.javamail.mock2.MailboxFolder;
+import de.saly.javamail.mock2.MockMailbox;
+import de.saly.javamail.mock2.Providers;
+import de.saly.javamail.mock2.test.support.MockTestException;
+import org.junit.Assert;
+import org.junit.Test;
 
 import javax.mail.Flags.Flag;
 import javax.mail.Folder;
@@ -40,17 +46,8 @@ import javax.mail.event.MessageCountEvent;
 import javax.mail.event.MessageCountListener;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.sun.mail.imap.IMAPFolder;
-import com.sun.mail.imap.IMAPStore;
-
-import de.saly.javamail.mock2.MailboxFolder;
-import de.saly.javamail.mock2.MockMailbox;
-import de.saly.javamail.mock2.Providers;
-import de.saly.javamail.mock2.test.support.MockTestException;
+import java.util.Arrays;
+import java.util.Properties;
 
 public class IMAPTestCase extends AbstractTestCase {
 
@@ -460,6 +457,16 @@ public class IMAPTestCase extends AbstractTestCase {
         Assert.assertEquals(1, level2.getMessageCount());
 
         Assert.assertEquals(2, root.list().length);
+    }
+
+    @Test
+    public void testGetMessageByUnknownUID() throws Exception {
+        final Store store = session.getStore("mock_imap");
+        store.connect("hendrik@unknown.com", null);
+        final Folder inbox = store.getFolder("INBOX");
+        inbox.open(Folder.READ_WRITE);
+        final IMAPFolder imapInbox = (IMAPFolder) inbox;
+        Assert.assertNull(imapInbox.getMessageByUID(666));
     }
 
 }


### PR DESCRIPTION
Fixes bug in IMAPMockFolder.getMessageByUID(long). Instead of returning a null value the method throws a NullPointerException for an unknown UID.